### PR TITLE
Fix comparison of disabled compaction strategies. 

### DIFF
--- a/Cassandra.ThriftClient.Tests/UnitTests/CoreTests/ColumnFamilyEqualityByPropertiesComparerTest.cs
+++ b/Cassandra.ThriftClient.Tests/UnitTests/CoreTests/ColumnFamilyEqualityByPropertiesComparerTest.cs
@@ -85,6 +85,11 @@ namespace Cassandra.ThriftClient.Tests.UnitTests.CoreTests
                     new ColumnFamily {Name = "name", CompactionStrategy = CompactionStrategy.SizeTieredCompactionStrategyDisabled()})
             );
             Assert.That(
+                !comparer.NeedUpdateColumnFamily(
+                    new ColumnFamily {Name = "name", CompactionStrategy = CompactionStrategy.SizeTieredCompactionStrategyDisabled()},
+                    new ColumnFamily {Name = "name", CompactionStrategy = new CompactionStrategy(CompactionStrategyType.SizeTiered, new CompactionStrategyOptions {Enabled = false, MinThreshold = 4, MaxThreshold = 32,})})
+            );
+            Assert.That(
                 comparer.NeedUpdateColumnFamily(
                     new ColumnFamily {Name = "name", CompactionStrategy = CompactionStrategy.SizeTieredCompactionStrategy(4, 32)},
                     new ColumnFamily {Name = "name", CompactionStrategy = CompactionStrategy.SizeTieredCompactionStrategyDisabled()})

--- a/Cassandra.ThriftClient/Scheme/ColumnFamilyEqualityByPropertiesComparer.cs
+++ b/Cassandra.ThriftClient/Scheme/ColumnFamilyEqualityByPropertiesComparer.cs
@@ -63,6 +63,9 @@ namespace SKBKontur.Cassandra.CassandraClient.Scheme
                 return true;
             if(lhs != null && rhs != null)
             {
+                if(lhs.Enabled == false && rhs.Enabled == false)
+                    return true;
+
                 return lhs.Enabled == rhs.Enabled &&
                        lhs.MinThreshold == rhs.MinThreshold &&
                        lhs.MaxThreshold == rhs.MaxThreshold &&


### PR DESCRIPTION
If compaction min/max thresholds are null thrift returns default values. It leads to unexpected update of tables when it's not needed.