### PR TITLE
Adapt MultiGetSlice/MultiGetCount queries to the bug in the Cassandra 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,5 @@
 - Fix comparison of disabled compaction strategies 
   (PR [#2](https://github.com/skbkontur/cassandra-thrift-client/pull/2)).
 - Add org.apache.cassandra.db.marshal.SimpleDateType to supported DataTypes.
+- Add retry logic for MultigetSlice/MultigetCount queries to avoid data skip that caused by the bug [CASSANDRA-14812](https://issues.apache.org/jira/browse/CASSANDRA-14812) 
+(PR [#3](https://github.com/skbkontur/cassandra-thrift-client/pull/3)).

--- a/Cassandra.ThriftClient.Tests/FunctionalTests/Tests/GetRowsTest.cs
+++ b/Cassandra.ThriftClient.Tests/FunctionalTests/Tests/GetRowsTest.cs
@@ -94,6 +94,18 @@ namespace Cassandra.ThriftClient.Tests.FunctionalTests.Tests
             }
         }
 
+        [Test]
+        public void TestGetNonexistentRows()
+        {
+            const int rowKeysCount = 100;
+            const int columnNamesCount = 100;
+            var rowKeys = new int[rowKeysCount].Select(x => Guid.NewGuid().ToString()).ToArray();
+            var intColumnNames = GetRandomColumnIndexesFromRange(0, columnNamesCount, columnNamesCount).ToArray();
+            var strColumnNames = intColumnNames.Select(IntToString).ToArray();
+            var res = columnFamilyConnection.GetRows(rowKeys, strColumnNames.Concat(new[]{100, 101, 102}.Select(IntToString)).ToArray());
+            Assert.IsEmpty(res);
+        }
+
         private string IntToString(int x)
         {
             return x.ToString("0000", CultureInfo.InvariantCulture);

--- a/Cassandra.ThriftClient.Tests/UnitTests/HelpersTests/MultigetQueryHelperTests.cs
+++ b/Cassandra.ThriftClient.Tests/UnitTests/HelpersTests/MultigetQueryHelperTests.cs
@@ -8,6 +8,8 @@ using NUnit.Framework;
 using SKBKontur.Cassandra.CassandraClient.Exceptions;
 using SKBKontur.Cassandra.CassandraClient.Helpers;
 
+using Vostok.Logging.Abstractions;
+
 namespace Cassandra.ThriftClient.Tests.UnitTests.HelpersTests
 {
     public class MultigetQueryHelperTests : TestBase
@@ -15,21 +17,21 @@ namespace Cassandra.ThriftClient.Tests.UnitTests.HelpersTests
         [Test]
         public void TestPartialFetcher()
         {
-            var result = DefaultMultigetQueryHelper.EnumerateAllKeysWithPartialFetcher(keys, ReturnFirstElementFetcherFactory());
+            var result = DefaultMultigetQueryHelper.EnumerateAllKeysWithPartialFetcher(keys, ReturnFirstElementFetcherFactory(), silentLog);
             CollectionAssert.AreEquivalent(result.Select(item => (Key : item.Key, Value : item.Value)), keysWithValues);
         }
 
         [Test]
         public void TestFullFetcher()
         {
-            var result = DefaultMultigetQueryHelper.EnumerateAllKeysWithPartialFetcher(keys, FullFetcherFactory());
+            var result = DefaultMultigetQueryHelper.EnumerateAllKeysWithPartialFetcher(keys, FullFetcherFactory(), silentLog);
             CollectionAssert.AreEquivalent(result.Select(item => (Key : item.Key, Value : item.Value)), keysWithValues);
         }
 
         [Test]
         public void TestFetcherThatShuffleRequestPrefix()
         {
-            var result = DefaultMultigetQueryHelper.EnumerateAllKeysWithPartialFetcher(keys, ReversePrefixFetcherFactory(prefixLength : 7));
+            var result = DefaultMultigetQueryHelper.EnumerateAllKeysWithPartialFetcher(keys, ReversePrefixFetcherFactory(prefixLength : 7), silentLog);
             CollectionAssert.AreEquivalent(result.Select(item => (Key : item.Key, Value : item.Value)), keysWithValues);
         }
 
@@ -42,7 +44,7 @@ namespace Cassandra.ThriftClient.Tests.UnitTests.HelpersTests
             const string consistencyLevel = "QUORUM";
 
             void FetchKeys() => new MultigetQueryHelper(commandName, keyspace, columnFamily, Apache.Cassandra.ConsistencyLevel.QUORUM)
-                .EnumerateAllKeysWithPartialFetcher(keys, EmptyFetcherFactory());
+                .EnumerateAllKeysWithPartialFetcher(keys, EmptyFetcherFactory(), silentLog);
 
             Assert.Throws(Is.TypeOf<CassandraClientInvalidResponseException>()
                             .And.Message.Contains(commandName)
@@ -54,7 +56,7 @@ namespace Cassandra.ThriftClient.Tests.UnitTests.HelpersTests
         [Test]
         public void TestFetcherThatDoesNotReturnRequestPrefix()
         {
-            var result = DefaultMultigetQueryHelper.EnumerateAllKeysWithPartialFetcher(keys, ReverseSuffixFetcherFactory(suffixLength : 7));
+            var result = DefaultMultigetQueryHelper.EnumerateAllKeysWithPartialFetcher(keys, ReverseSuffixFetcherFactory(suffixLength : 7), silentLog);
             CollectionAssert.AreEquivalent(result.Select(item => (Key : item.Key, Value : item.Value)), keysWithValues);
         }
 
@@ -96,6 +98,7 @@ namespace Cassandra.ThriftClient.Tests.UnitTests.HelpersTests
         }
 
         private static byte[] GetBytes(string s) => Encoding.UTF8.GetBytes(s);
+        private static ILog silentLog = new SilentLog();
         private static readonly List<byte[]> keys = Enumerable.Range(0, 100).Select(i => GetBytes(i.ToString())).ToList();
         private static readonly List<(byte[] Key, int Value)> keysWithValues = keys.Select(key => (Key : key, Value : (int)key[0])).ToList();
     }

--- a/Cassandra.ThriftClient.Tests/UnitTests/HelpersTests/MultigetQueryHelperTests.cs
+++ b/Cassandra.ThriftClient.Tests/UnitTests/HelpersTests/MultigetQueryHelperTests.cs
@@ -15,21 +15,21 @@ namespace Cassandra.ThriftClient.Tests.UnitTests.HelpersTests
         [Test]
         public void TestPartialFetcher()
         {
-            var result = Default().EnumerateAllKeysWithPartialFetcher(keys, ReturnFirstElementFetcherFactory());
+            var result = DefaultMultigetQueryHelper.EnumerateAllKeysWithPartialFetcher(keys, ReturnFirstElementFetcherFactory());
             CollectionAssert.AreEquivalent(result.Select(item => (Key : item.Key, Value : item.Value)), keysWithValues);
         }
 
         [Test]
         public void TestFullFetcher()
         {
-            var result = Default().EnumerateAllKeysWithPartialFetcher(keys, FullFetcherFactory());
+            var result = DefaultMultigetQueryHelper.EnumerateAllKeysWithPartialFetcher(keys, FullFetcherFactory());
             CollectionAssert.AreEquivalent(result.Select(item => (Key : item.Key, Value : item.Value)), keysWithValues);
         }
 
         [Test]
         public void TestFetcherThatShuffleRequestPrefix()
         {
-            var result = Default().EnumerateAllKeysWithPartialFetcher(keys, ReversePrefixFetcherFactory(prefixLength : 7));
+            var result = DefaultMultigetQueryHelper.EnumerateAllKeysWithPartialFetcher(keys, ReversePrefixFetcherFactory(prefixLength : 7));
             CollectionAssert.AreEquivalent(result.Select(item => (Key : item.Key, Value : item.Value)), keysWithValues);
         }
 
@@ -41,7 +41,7 @@ namespace Cassandra.ThriftClient.Tests.UnitTests.HelpersTests
             const string columnFamily = "test_column_family_name";
             const string consistencyLevel = "QUORUM";
 
-            void FetchKeys() => new MultigetQueryHelpers(commandName, keyspace, columnFamily, Apache.Cassandra.ConsistencyLevel.QUORUM)
+            void FetchKeys() => new MultigetQueryHelper(commandName, keyspace, columnFamily, Apache.Cassandra.ConsistencyLevel.QUORUM)
                 .EnumerateAllKeysWithPartialFetcher(keys, EmptyFetcherFactory());
 
             Assert.Throws(Is.TypeOf<CassandraClientInvalidResponseException>()
@@ -54,14 +54,11 @@ namespace Cassandra.ThriftClient.Tests.UnitTests.HelpersTests
         [Test]
         public void TestFetcherThatDoesNotReturnRequestPrefix()
         {
-            var result = Default().EnumerateAllKeysWithPartialFetcher(keys, ReverseSuffixFetcherFactory(suffixLength : 7));
+            var result = DefaultMultigetQueryHelper.EnumerateAllKeysWithPartialFetcher(keys, ReverseSuffixFetcherFactory(suffixLength : 7));
             CollectionAssert.AreEquivalent(result.Select(item => (Key : item.Key, Value : item.Value)), keysWithValues);
         }
 
-        private MultigetQueryHelpers Default()
-        {
-            return new MultigetQueryHelpers(string.Empty, string.Empty, string.Empty, null);
-        }
+        private MultigetQueryHelper DefaultMultigetQueryHelper => new MultigetQueryHelper(string.Empty, string.Empty, string.Empty, null);
 
         private static Func<List<byte[]>, Dictionary<byte[], int>> ReturnFirstElementFetcherFactory()
         {

--- a/Cassandra.ThriftClient.Tests/UnitTests/HelpersTests/MultigetQueryHelperTests.cs
+++ b/Cassandra.ThriftClient.Tests/UnitTests/HelpersTests/MultigetQueryHelperTests.cs
@@ -98,7 +98,7 @@ namespace Cassandra.ThriftClient.Tests.UnitTests.HelpersTests
         }
 
         private static byte[] GetBytes(string s) => Encoding.UTF8.GetBytes(s);
-        private static ILog silentLog = new SilentLog();
+        private static readonly ILog silentLog = new SilentLog();
         private static readonly List<byte[]> keys = Enumerable.Range(0, 100).Select(i => GetBytes(i.ToString())).ToList();
         private static readonly List<(byte[] Key, int Value)> keysWithValues = keys.Select(key => (Key : key, Value : (int)key[0])).ToList();
     }

--- a/Cassandra.ThriftClient.Tests/UnitTests/HelpersTests/MultigetQueryHelperTests.cs
+++ b/Cassandra.ThriftClient.Tests/UnitTests/HelpersTests/MultigetQueryHelperTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using NUnit.Framework;
+
+using SKBKontur.Cassandra.CassandraClient.Exceptions;
+using SKBKontur.Cassandra.CassandraClient.Helpers;
+
+namespace Cassandra.ThriftClient.Tests.UnitTests.HelpersTests
+{
+    public class MultigetQueryHelperTests : TestBase
+    {
+        [Test]
+        public void TestPartialFetcher()
+        {
+            var result = MultigetQueryHelpers.EnumerateAllKeysWithPartialFetcher(keys, ReturnFirstElementFetcherFactory());
+            CollectionAssert.AreEquivalent(result.Select(item => (Key : item.Key, Value : item.Value)), keysWithValues);
+        }
+
+        [Test]
+        public void TestFullFetcher()
+        {
+            var result = MultigetQueryHelpers.EnumerateAllKeysWithPartialFetcher(keys, FullFetcherFactory());
+            CollectionAssert.AreEquivalent(result.Select(item => (Key : item.Key, Value : item.Value)), keysWithValues);
+        }
+
+        [Test]
+        public void TestFetcherThatShuffleRequestPrefix()
+        {
+            var result = MultigetQueryHelpers.EnumerateAllKeysWithPartialFetcher(keys, ReversePrefixFetcherFactory(prefixLength : 7));
+            CollectionAssert.AreEquivalent(result.Select(item => (Key : item.Key, Value : item.Value)), keysWithValues);
+        }
+
+        [Test]
+        public void TestFetcherThatStuck()
+        {
+            Assert.Throws<CassandraClientInvalidResponseException>(
+                () => MultigetQueryHelpers.EnumerateAllKeysWithPartialFetcher(keys, EmptyFetcherFactory()));
+        }
+
+        [Test]
+        public void TestFetcherThatDoesNotReturnRequestPrefix()
+        {
+            var result = MultigetQueryHelpers.EnumerateAllKeysWithPartialFetcher(keys, ReverseSuffixFetcherFactory(suffixLength : 7));
+            CollectionAssert.AreEquivalent(result.Select(item => (Key : item.Key, Value : item.Value)), keysWithValues);
+        }
+
+        private static Func<List<byte[]>, Dictionary<byte[], int>> ReturnFirstElementFetcherFactory()
+        {
+            return k => new Dictionary<byte[], int> {[k[0]] = k[0][0]};
+        }
+
+        private static Func<List<byte[]>, Dictionary<byte[], int>> FullFetcherFactory()
+        {
+            return k => k.Select(key => (Key : key, Value : (int)key[0])).ToDictionary(item => item.Key, item => item.Value);
+        }
+
+        private static Func<List<byte[]>, Dictionary<byte[], int>> EmptyFetcherFactory()
+        {
+            return _ => new Dictionary<byte[], int>();
+        }
+
+        private static Func<List<byte[]>, Dictionary<byte[], int>> ReversePrefixFetcherFactory(int prefixLength)
+        {
+            return k =>
+                {
+                    var reversedKeys = k.Take(prefixLength).ToList();
+                    reversedKeys.Reverse();
+                    return reversedKeys.Select(key => (Key : key, Value : (int)key[0])).ToDictionary(item => item.Key, item => item.Value);
+                };
+        }
+
+        private static Func<List<byte[]>, Dictionary<byte[], int>> ReverseSuffixFetcherFactory(int suffixLength)
+        {
+            return k =>
+                {
+                    var reversedKeys = k.Skip(k.Count - suffixLength).ToList();
+                    reversedKeys.Reverse();
+                    return reversedKeys.Select(key => (Key : key, Value : (int)key[0])).ToDictionary(item => item.Key, item => item.Value);
+                };
+        }
+
+        private static byte[] GetBytes(string s) => Encoding.UTF8.GetBytes(s);
+        private static readonly List<byte[]> keys = Enumerable.Range(0, 100).Select(i => GetBytes(i.ToString())).ToList();
+        private static readonly List<(byte[] Key, int Value)> keysWithValues = keys.Select(key => (Key : key, Value : (int)key[0])).ToList();
+    }
+}

--- a/Cassandra.ThriftClient.Tests/UnitTests/HelpersTests/MultigetQueryHelperTests.cs
+++ b/Cassandra.ThriftClient.Tests/UnitTests/HelpersTests/MultigetQueryHelperTests.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-using Apache.Cassandra;
-
 using NUnit.Framework;
 
 using SKBKontur.Cassandra.CassandraClient.Exceptions;
@@ -38,14 +36,19 @@ namespace Cassandra.ThriftClient.Tests.UnitTests.HelpersTests
         [Test]
         public void TestFetcherThatStuck()
         {
-            var keyspace = "test_keyspace_name";
-            var columnFamily = "test_column_family_name";
-            var consistencyLevel = "QUORUM";
+            const string commandName = "test_command_name";
+            const string keyspace = "test_keyspace_name";
+            const string columnFamily = "test_column_family_name";
+            const string consistencyLevel = "QUORUM";
+
+            void FetchKeys() => new MultigetQueryHelpers(commandName, keyspace, columnFamily, Apache.Cassandra.ConsistencyLevel.QUORUM)
+                .EnumerateAllKeysWithPartialFetcher(keys, EmptyFetcherFactory());
+
             Assert.Throws(Is.TypeOf<CassandraClientInvalidResponseException>()
+                            .And.Message.Contains(commandName)
                             .And.Message.Contains(keyspace)
                             .And.Message.Contains(columnFamily)
-                            .And.Message.Contains(consistencyLevel),
-                          () => new MultigetQueryHelpers(keyspace, columnFamily, ConsistencyLevel.QUORUM).EnumerateAllKeysWithPartialFetcher(keys, EmptyFetcherFactory()));
+                            .And.Message.Contains(consistencyLevel), FetchKeys);
         }
 
         [Test]
@@ -57,7 +60,7 @@ namespace Cassandra.ThriftClient.Tests.UnitTests.HelpersTests
 
         private MultigetQueryHelpers Default()
         {
-            return new MultigetQueryHelpers(string.Empty, string.Empty, null);
+            return new MultigetQueryHelpers(string.Empty, string.Empty, string.Empty, null);
         }
 
         private static Func<List<byte[]>, Dictionary<byte[], int>> ReturnFirstElementFetcherFactory()

--- a/Cassandra.ThriftClient/Abstractions/ICommand.cs
+++ b/Cassandra.ThriftClient/Abstractions/ICommand.cs
@@ -1,8 +1,10 @@
-﻿namespace SKBKontur.Cassandra.CassandraClient.Abstractions
+﻿using Vostok.Logging.Abstractions;
+
+namespace SKBKontur.Cassandra.CassandraClient.Abstractions
 {
     internal interface ICommand
     {
-        void Execute(Apache.Cassandra.Cassandra.Client client);
+        void Execute(Apache.Cassandra.Cassandra.Client client, ILog logger);
         string Name { get; }
         CommandContext CommandContext { get; }
     }

--- a/Cassandra.ThriftClient/Commands/Base/CommandBase.cs
+++ b/Cassandra.ThriftClient/Commands/Base/CommandBase.cs
@@ -1,10 +1,12 @@
 using SKBKontur.Cassandra.CassandraClient.Abstractions;
 
+using Vostok.Logging.Abstractions;
+
 namespace SKBKontur.Cassandra.CassandraClient.Commands.Base
 {
     internal abstract class CommandBase : ICommand
     {
-        public abstract void Execute(Apache.Cassandra.Cassandra.Client client);
+        public abstract void Execute(Apache.Cassandra.Cassandra.Client client, ILog logger);
         public string Name => GetType().Name;
         public virtual CommandContext CommandContext => new CommandContext();
     }

--- a/Cassandra.ThriftClient/Commands/Simple/Read/GetCommand.cs
+++ b/Cassandra.ThriftClient/Commands/Simple/Read/GetCommand.cs
@@ -5,6 +5,8 @@ using JetBrains.Annotations;
 using SKBKontur.Cassandra.CassandraClient.Abstractions;
 using SKBKontur.Cassandra.CassandraClient.Commands.Base;
 
+using Vostok.Logging.Abstractions;
+
 using ConsistencyLevel = Apache.Cassandra.ConsistencyLevel;
 
 namespace SKBKontur.Cassandra.CassandraClient.Commands.Simple.Read
@@ -24,7 +26,7 @@ namespace SKBKontur.Cassandra.CassandraClient.Commands.Simple.Read
 
         public int QueriedPartitionsCount => 1;
 
-        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient)
+        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient, ILog logger)
         {
             ColumnOrSuperColumn columnOrSupercolumn = null;
             var columnPath = BuildColumnPath(columnName);

--- a/Cassandra.ThriftClient/Commands/Simple/Read/GetCountCommand.cs
+++ b/Cassandra.ThriftClient/Commands/Simple/Read/GetCountCommand.cs
@@ -4,6 +4,8 @@ using SKBKontur.Cassandra.CassandraClient.Abstractions;
 using SKBKontur.Cassandra.CassandraClient.Abstractions.Internal;
 using SKBKontur.Cassandra.CassandraClient.Commands.Base;
 
+using Vostok.Logging.Abstractions;
+
 using ConsistencyLevel = Apache.Cassandra.ConsistencyLevel;
 
 namespace SKBKontur.Cassandra.CassandraClient.Commands.Simple.Read
@@ -23,7 +25,7 @@ namespace SKBKontur.Cassandra.CassandraClient.Commands.Simple.Read
 
         public int QueriedPartitionsCount => 1;
 
-        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient)
+        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient, ILog logger)
         {
             Count = cassandraClient.get_count(PartitionKey, BuildColumnParent(), predicate.ToCassandraSlicePredicate(), consistencyLevel);
         }

--- a/Cassandra.ThriftClient/Commands/Simple/Read/GetKeyRangeSliceCommand.cs
+++ b/Cassandra.ThriftClient/Commands/Simple/Read/GetKeyRangeSliceCommand.cs
@@ -7,6 +7,8 @@ using SKBKontur.Cassandra.CassandraClient.Abstractions;
 using SKBKontur.Cassandra.CassandraClient.Abstractions.Internal;
 using SKBKontur.Cassandra.CassandraClient.Commands.Base;
 
+using Vostok.Logging.Abstractions;
+
 using ConsistencyLevel = Apache.Cassandra.ConsistencyLevel;
 using KeyRange = SKBKontur.Cassandra.CassandraClient.Abstractions.Internal.KeyRange;
 using SlicePredicate = SKBKontur.Cassandra.CassandraClient.Abstractions.Internal.SlicePredicate;
@@ -23,7 +25,7 @@ namespace SKBKontur.Cassandra.CassandraClient.Commands.Simple.Read
             this.predicate = predicate;
         }
 
-        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient)
+        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient, ILog logger)
         {
             Output = null;
             var columnParent = BuildColumnParent();

--- a/Cassandra.ThriftClient/Commands/Simple/Read/GetSliceCommand.cs
+++ b/Cassandra.ThriftClient/Commands/Simple/Read/GetSliceCommand.cs
@@ -9,6 +9,8 @@ using SKBKontur.Cassandra.CassandraClient.Abstractions;
 using SKBKontur.Cassandra.CassandraClient.Abstractions.Internal;
 using SKBKontur.Cassandra.CassandraClient.Commands.Base;
 
+using Vostok.Logging.Abstractions;
+
 using ConsistencyLevel = Apache.Cassandra.ConsistencyLevel;
 using SlicePredicate = SKBKontur.Cassandra.CassandraClient.Abstractions.Internal.SlicePredicate;
 
@@ -29,7 +31,7 @@ namespace SKBKontur.Cassandra.CassandraClient.Commands.Simple.Read
 
         public int QueriedPartitionsCount => 1;
 
-        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient)
+        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient, ILog logger)
         {
             Output = null;
             var columnParent = BuildColumnParent();

--- a/Cassandra.ThriftClient/Commands/Simple/Read/MultiGetCountCommand.cs
+++ b/Cassandra.ThriftClient/Commands/Simple/Read/MultiGetCountCommand.cs
@@ -25,10 +25,10 @@ namespace SKBKontur.Cassandra.CassandraClient.Commands.Simple.Read
         {
             var columnParent = BuildColumnParent();
             var slicePredicate = predicate.ToCassandraSlicePredicate();
-            Output = new MultigetQueryHelpers(keyspace, columnFamily, consistencyLevel).EnumerateAllKeysWithPartialFetcher(
-                keys,
-                queryKeys => cassandraClient.multiget_count(queryKeys, columnParent, slicePredicate, consistencyLevel),
-                logger.ForContext($"MultiGetCountCommand[keyspace='{keyspace}', columnFamily='{columnFamily}', consistencyLevel='{consistencyLevel}']"));
+            Output = new MultigetQueryHelpers(nameof(MultiGetCountCommand), keyspace, columnFamily, consistencyLevel)
+                .EnumerateAllKeysWithPartialFetcher(
+                    keys,
+                    queryKeys => cassandraClient.multiget_count(queryKeys, columnParent, slicePredicate, consistencyLevel), logger);
         }
 
         public Dictionary<byte[], int> Output { get; private set; }

--- a/Cassandra.ThriftClient/Commands/Simple/Read/MultiGetCountCommand.cs
+++ b/Cassandra.ThriftClient/Commands/Simple/Read/MultiGetCountCommand.cs
@@ -27,7 +27,7 @@ namespace SKBKontur.Cassandra.CassandraClient.Commands.Simple.Read
             var slicePredicate = predicate.ToCassandraSlicePredicate();
             Output = MultigetQueryHelpers.EnumerateAllKeysWithPartialFetcher(
                 keys,
-                queryKeys => cassandraClient.multiget_count(keys, columnParent, slicePredicate, consistencyLevel),
+                queryKeys => cassandraClient.multiget_count(queryKeys, columnParent, slicePredicate, consistencyLevel),
                 logger.ForContext($"MultiGetCountCommand[keyspace='{keyspace}', columnFamily='{columnFamily}', consistencyLevel='{consistencyLevel}']"));
         }
 

--- a/Cassandra.ThriftClient/Commands/Simple/Read/MultiGetCountCommand.cs
+++ b/Cassandra.ThriftClient/Commands/Simple/Read/MultiGetCountCommand.cs
@@ -3,7 +3,6 @@
 using SKBKontur.Cassandra.CassandraClient.Abstractions;
 using SKBKontur.Cassandra.CassandraClient.Abstractions.Internal;
 using SKBKontur.Cassandra.CassandraClient.Commands.Base;
-using SKBKontur.Cassandra.CassandraClient.Exceptions;
 using SKBKontur.Cassandra.CassandraClient.Helpers;
 
 using Vostok.Logging.Abstractions;
@@ -29,7 +28,7 @@ namespace SKBKontur.Cassandra.CassandraClient.Commands.Simple.Read
             Output = MultigetQueryHelpers.EnumerateAllKeysWithPartialFetcher(
                 keys,
                 queryKeys => cassandraClient.multiget_count(keys, columnParent, slicePredicate, consistencyLevel),
-                logger.WithContext($"MultiGetCountCommand[keyspace='{keyspace}', columnFamily='{columnFamily}', consistencyLevel='{consistencyLevel}']"));
+                logger.ForContext($"MultiGetCountCommand[keyspace='{keyspace}', columnFamily='{columnFamily}', consistencyLevel='{consistencyLevel}']"));
         }
 
         public Dictionary<byte[], int> Output { get; private set; }

--- a/Cassandra.ThriftClient/Commands/Simple/Read/MultiGetCountCommand.cs
+++ b/Cassandra.ThriftClient/Commands/Simple/Read/MultiGetCountCommand.cs
@@ -25,7 +25,7 @@ namespace SKBKontur.Cassandra.CassandraClient.Commands.Simple.Read
         {
             var columnParent = BuildColumnParent();
             var slicePredicate = predicate.ToCassandraSlicePredicate();
-            Output = MultigetQueryHelpers.EnumerateAllKeysWithPartialFetcher(
+            Output = new MultigetQueryHelpers(keyspace, columnFamily, consistencyLevel).EnumerateAllKeysWithPartialFetcher(
                 keys,
                 queryKeys => cassandraClient.multiget_count(queryKeys, columnParent, slicePredicate, consistencyLevel),
                 logger.ForContext($"MultiGetCountCommand[keyspace='{keyspace}', columnFamily='{columnFamily}', consistencyLevel='{consistencyLevel}']"));

--- a/Cassandra.ThriftClient/Commands/Simple/Read/MultiGetCountCommand.cs
+++ b/Cassandra.ThriftClient/Commands/Simple/Read/MultiGetCountCommand.cs
@@ -4,6 +4,8 @@ using SKBKontur.Cassandra.CassandraClient.Abstractions;
 using SKBKontur.Cassandra.CassandraClient.Abstractions.Internal;
 using SKBKontur.Cassandra.CassandraClient.Commands.Base;
 
+using Vostok.Logging.Abstractions;
+
 using ConsistencyLevel = Apache.Cassandra.ConsistencyLevel;
 
 namespace SKBKontur.Cassandra.CassandraClient.Commands.Simple.Read
@@ -18,7 +20,7 @@ namespace SKBKontur.Cassandra.CassandraClient.Commands.Simple.Read
             this.predicate = predicate ?? new SlicePredicate(new SliceRange {Count = int.MaxValue});
         }
 
-        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient)
+        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient, ILog logger)
         {
             Output = cassandraClient.multiget_count(keys, BuildColumnParent(), predicate.ToCassandraSlicePredicate(), consistencyLevel);
         }

--- a/Cassandra.ThriftClient/Commands/Simple/Read/MultiGetCountCommand.cs
+++ b/Cassandra.ThriftClient/Commands/Simple/Read/MultiGetCountCommand.cs
@@ -25,7 +25,7 @@ namespace SKBKontur.Cassandra.CassandraClient.Commands.Simple.Read
         {
             var columnParent = BuildColumnParent();
             var slicePredicate = predicate.ToCassandraSlicePredicate();
-            Output = new MultigetQueryHelpers(nameof(MultiGetCountCommand), keyspace, columnFamily, consistencyLevel)
+            Output = new MultigetQueryHelper(nameof(MultiGetCountCommand), keyspace, columnFamily, consistencyLevel)
                 .EnumerateAllKeysWithPartialFetcher(
                     keys,
                     queryKeys => cassandraClient.multiget_count(queryKeys, columnParent, slicePredicate, consistencyLevel), logger);

--- a/Cassandra.ThriftClient/Commands/Simple/Read/MultiGetSliceCommand.cs
+++ b/Cassandra.ThriftClient/Commands/Simple/Read/MultiGetSliceCommand.cs
@@ -29,7 +29,7 @@ namespace SKBKontur.Cassandra.CassandraClient.Commands.Simple.Read
         {
             var columnParent = BuildColumnParent();
             var slicePredicate = predicate.ToCassandraSlicePredicate();
-            var output = MultigetQueryHelpers.EnumerateAllKeysWithPartialFetcher(
+            var output = new MultigetQueryHelpers(keyspace, columnFamily, consistencyLevel).EnumerateAllKeysWithPartialFetcher(
                 keys,
                 queryKeys => cassandraClient.multiget_slice(queryKeys, columnParent, slicePredicate, consistencyLevel),
                 logger.ForContext($"MultiGetSliceCommand[keyspace='{keyspace}', columnFamily='{columnFamily}', consistencyLevel='{consistencyLevel}']"));

--- a/Cassandra.ThriftClient/Commands/Simple/Read/MultiGetSliceCommand.cs
+++ b/Cassandra.ThriftClient/Commands/Simple/Read/MultiGetSliceCommand.cs
@@ -7,6 +7,8 @@ using SKBKontur.Cassandra.CassandraClient.Abstractions;
 using SKBKontur.Cassandra.CassandraClient.Abstractions.Internal;
 using SKBKontur.Cassandra.CassandraClient.Commands.Base;
 
+using Vostok.Logging.Abstractions;
+
 using ConsistencyLevel = Apache.Cassandra.ConsistencyLevel;
 using SlicePredicate = SKBKontur.Cassandra.CassandraClient.Abstractions.Internal.SlicePredicate;
 
@@ -22,7 +24,7 @@ namespace SKBKontur.Cassandra.CassandraClient.Commands.Simple.Read
             this.predicate = predicate;
         }
 
-        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient)
+        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient, ILog logger)
         {
             var output = cassandraClient.multiget_slice(keys, BuildColumnParent(), predicate.ToCassandraSlicePredicate(), consistencyLevel);
             BuildOut(output);

--- a/Cassandra.ThriftClient/Commands/Simple/Read/MultiGetSliceCommand.cs
+++ b/Cassandra.ThriftClient/Commands/Simple/Read/MultiGetSliceCommand.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
 
 using Apache.Cassandra;
@@ -33,7 +32,7 @@ namespace SKBKontur.Cassandra.CassandraClient.Commands.Simple.Read
             var output = MultigetQueryHelpers.EnumerateAllKeysWithPartialFetcher(
                 keys,
                 queryKeys => cassandraClient.multiget_slice(queryKeys, columnParent, slicePredicate, consistencyLevel),
-                logger.WithContext($"MultiGetSliceCommand[keyspace='{keyspace}', columnFamily='{columnFamily}', consistencyLevel='{consistencyLevel}']"));
+                logger.ForContext($"MultiGetSliceCommand[keyspace='{keyspace}', columnFamily='{columnFamily}', consistencyLevel='{consistencyLevel}']"));
             BuildOut(output);
         }
 

--- a/Cassandra.ThriftClient/Commands/Simple/Read/MultiGetSliceCommand.cs
+++ b/Cassandra.ThriftClient/Commands/Simple/Read/MultiGetSliceCommand.cs
@@ -29,7 +29,7 @@ namespace SKBKontur.Cassandra.CassandraClient.Commands.Simple.Read
         {
             var columnParent = BuildColumnParent();
             var slicePredicate = predicate.ToCassandraSlicePredicate();
-            var output = new MultigetQueryHelpers(nameof(MultiGetSliceCommand), keyspace, columnFamily, consistencyLevel)
+            var output = new MultigetQueryHelper(nameof(MultiGetSliceCommand), keyspace, columnFamily, consistencyLevel)
                 .EnumerateAllKeysWithPartialFetcher(
                     keys,
                     queryKeys => cassandraClient.multiget_slice(queryKeys, columnParent, slicePredicate, consistencyLevel), logger);

--- a/Cassandra.ThriftClient/Commands/Simple/Read/MultiGetSliceCommand.cs
+++ b/Cassandra.ThriftClient/Commands/Simple/Read/MultiGetSliceCommand.cs
@@ -29,10 +29,10 @@ namespace SKBKontur.Cassandra.CassandraClient.Commands.Simple.Read
         {
             var columnParent = BuildColumnParent();
             var slicePredicate = predicate.ToCassandraSlicePredicate();
-            var output = new MultigetQueryHelpers(keyspace, columnFamily, consistencyLevel).EnumerateAllKeysWithPartialFetcher(
-                keys,
-                queryKeys => cassandraClient.multiget_slice(queryKeys, columnParent, slicePredicate, consistencyLevel),
-                logger.ForContext($"MultiGetSliceCommand[keyspace='{keyspace}', columnFamily='{columnFamily}', consistencyLevel='{consistencyLevel}']"));
+            var output = new MultigetQueryHelpers(nameof(MultiGetSliceCommand), keyspace, columnFamily, consistencyLevel)
+                .EnumerateAllKeysWithPartialFetcher(
+                    keys,
+                    queryKeys => cassandraClient.multiget_slice(queryKeys, columnParent, slicePredicate, consistencyLevel), logger);
             BuildOut(output);
         }
 

--- a/Cassandra.ThriftClient/Commands/Simple/Write/BatchMutateCommand.cs
+++ b/Cassandra.ThriftClient/Commands/Simple/Write/BatchMutateCommand.cs
@@ -8,6 +8,8 @@ using SKBKontur.Cassandra.CassandraClient.Abstractions.Internal;
 using SKBKontur.Cassandra.CassandraClient.Commands.Base;
 using SKBKontur.Cassandra.CassandraClient.Helpers;
 
+using Vostok.Logging.Abstractions;
+
 using ConsistencyLevel = Apache.Cassandra.ConsistencyLevel;
 
 namespace SKBKontur.Cassandra.CassandraClient.Commands.Simple.Write
@@ -21,7 +23,7 @@ namespace SKBKontur.Cassandra.CassandraClient.Commands.Simple.Write
             this.mutations = mutations;
         }
 
-        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient)
+        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient, ILog logger)
         {
             var mutationMap = TranslateMutations();
             cassandraClient.batch_mutate(mutationMap, consistencyLevel);

--- a/Cassandra.ThriftClient/Commands/Simple/Write/DeleteRowCommand.cs
+++ b/Cassandra.ThriftClient/Commands/Simple/Write/DeleteRowCommand.cs
@@ -6,6 +6,8 @@ using SKBKontur.Cassandra.CassandraClient.Abstractions;
 using SKBKontur.Cassandra.CassandraClient.Commands.Base;
 using SKBKontur.Cassandra.CassandraClient.Core;
 
+using Vostok.Logging.Abstractions;
+
 using ConsistencyLevel = Apache.Cassandra.ConsistencyLevel;
 
 namespace SKBKontur.Cassandra.CassandraClient.Commands.Simple.Write
@@ -25,7 +27,7 @@ namespace SKBKontur.Cassandra.CassandraClient.Commands.Simple.Write
 
         public int QueriedPartitionsCount => 1;
 
-        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient)
+        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient, ILog logger)
         {
             cassandraClient.remove(
                 PartitionKey,

--- a/Cassandra.ThriftClient/Commands/Simple/Write/InsertCommand.cs
+++ b/Cassandra.ThriftClient/Commands/Simple/Write/InsertCommand.cs
@@ -3,6 +3,8 @@ using JetBrains.Annotations;
 using SKBKontur.Cassandra.CassandraClient.Abstractions;
 using SKBKontur.Cassandra.CassandraClient.Commands.Base;
 
+using Vostok.Logging.Abstractions;
+
 using ConsistencyLevel = Apache.Cassandra.ConsistencyLevel;
 
 namespace SKBKontur.Cassandra.CassandraClient.Commands.Simple.Write
@@ -22,7 +24,7 @@ namespace SKBKontur.Cassandra.CassandraClient.Commands.Simple.Write
 
         public int QueriedPartitionsCount => 1;
 
-        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient)
+        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient, ILog logger)
         {
             cassandraClient.insert(PartitionKey, BuildColumnParent(), column.ToCassandraColumn(), consistencyLevel);
         }

--- a/Cassandra.ThriftClient/Commands/System/Read/DescribeKeySpaceCommand.cs
+++ b/Cassandra.ThriftClient/Commands/System/Read/DescribeKeySpaceCommand.cs
@@ -1,6 +1,8 @@
 ﻿using SKBKontur.Cassandra.CassandraClient.Abstractions;
 using SKBKontur.Cassandra.CassandraClient.Commands.Base;
 
+using Vostok.Logging.Abstractions;
+
 namespace SKBKontur.Cassandra.CassandraClient.Commands.System.Read
 {
     internal class DescribeKeyspaceCommand : KeyspaceDependantCommandBase, IFierceCommand
@@ -10,7 +12,7 @@ namespace SKBKontur.Cassandra.CassandraClient.Commands.System.Read
         {
         }
 
-        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient)
+        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient, ILog logger)
         {
             var keyspaceDescription = cassandraClient.describe_keyspace(keyspace);
             KeyspaceInformation = keyspaceDescription.FromCassandraKsDef();

--- a/Cassandra.ThriftClient/Commands/System/Read/DescribeVersionCommand.cs
+++ b/Cassandra.ThriftClient/Commands/System/Read/DescribeVersionCommand.cs
@@ -1,11 +1,13 @@
 ﻿using SKBKontur.Cassandra.CassandraClient.Abstractions;
 using SKBKontur.Cassandra.CassandraClient.Commands.Base;
 
+using Vostok.Logging.Abstractions;
+
 namespace SKBKontur.Cassandra.CassandraClient.Commands.System.Read
 {
     internal class DescribeVersionCommand : CommandBase, IFierceCommand
     {
-        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient)
+        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient, ILog logger)
         {
             Version = cassandraClient.describe_version();
         }

--- a/Cassandra.ThriftClient/Commands/System/Read/RetrieveClusterPartitionerCommand.cs
+++ b/Cassandra.ThriftClient/Commands/System/Read/RetrieveClusterPartitionerCommand.cs
@@ -1,11 +1,13 @@
 ﻿using SKBKontur.Cassandra.CassandraClient.Abstractions;
 using SKBKontur.Cassandra.CassandraClient.Commands.Base;
 
+using Vostok.Logging.Abstractions;
+
 namespace SKBKontur.Cassandra.CassandraClient.Commands.System.Read
 {
     internal class RetrieveClusterPartitionerCommand : CommandBase, IFierceCommand
     {
-        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient)
+        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient, ILog logger)
         {
             Partitioner = cassandraClient.describe_partitioner();
         }

--- a/Cassandra.ThriftClient/Commands/System/Read/RetrieveKeySpacesCommand.cs
+++ b/Cassandra.ThriftClient/Commands/System/Read/RetrieveKeySpacesCommand.cs
@@ -7,11 +7,13 @@ using Apache.Cassandra;
 using SKBKontur.Cassandra.CassandraClient.Abstractions;
 using SKBKontur.Cassandra.CassandraClient.Commands.Base;
 
+using Vostok.Logging.Abstractions;
+
 namespace SKBKontur.Cassandra.CassandraClient.Commands.System.Read
 {
     internal class RetrieveKeyspacesCommand : CommandBase, IFierceCommand
     {
-        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient)
+        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient, ILog logger)
         {
             var keySpaces = cassandraClient.describe_keyspaces();
             Keyspaces = BuildKeyspaces(keySpaces);

--- a/Cassandra.ThriftClient/Commands/System/Write/AddColumnFamilyCommand.cs
+++ b/Cassandra.ThriftClient/Commands/System/Write/AddColumnFamilyCommand.cs
@@ -1,6 +1,8 @@
 ﻿using SKBKontur.Cassandra.CassandraClient.Abstractions;
 using SKBKontur.Cassandra.CassandraClient.Commands.Base;
 
+using Vostok.Logging.Abstractions;
+
 namespace SKBKontur.Cassandra.CassandraClient.Commands.System.Write
 {
     internal class AddColumnFamilyCommand : KeyspaceDependantCommandBase, IFierceCommand
@@ -11,7 +13,7 @@ namespace SKBKontur.Cassandra.CassandraClient.Commands.System.Write
             this.columnFamilyDefinition = columnFamilyDefinition;
         }
 
-        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient)
+        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient, ILog logger)
         {
             Output = cassandraClient.system_add_column_family(columnFamilyDefinition.ToCassandraCfDef(keyspace));
         }

--- a/Cassandra.ThriftClient/Commands/System/Write/AddKeyspaceCommand.cs
+++ b/Cassandra.ThriftClient/Commands/System/Write/AddKeyspaceCommand.cs
@@ -1,6 +1,8 @@
 ﻿using SKBKontur.Cassandra.CassandraClient.Abstractions;
 using SKBKontur.Cassandra.CassandraClient.Commands.Base;
 
+using Vostok.Logging.Abstractions;
+
 namespace SKBKontur.Cassandra.CassandraClient.Commands.System.Write
 {
     internal class AddKeyspaceCommand : CommandBase, IFierceCommand
@@ -10,7 +12,7 @@ namespace SKBKontur.Cassandra.CassandraClient.Commands.System.Write
             this.keyspaceDefinition = keyspaceDefinition;
         }
 
-        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient)
+        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient, ILog logger)
         {
             Output = cassandraClient.system_add_keyspace(keyspaceDefinition.ToCassandraKsDef());
         }

--- a/Cassandra.ThriftClient/Commands/System/Write/DropColumnFamilyCommand.cs
+++ b/Cassandra.ThriftClient/Commands/System/Write/DropColumnFamilyCommand.cs
@@ -1,6 +1,8 @@
 ﻿using SKBKontur.Cassandra.CassandraClient.Abstractions;
 using SKBKontur.Cassandra.CassandraClient.Commands.Base;
 
+using Vostok.Logging.Abstractions;
+
 namespace SKBKontur.Cassandra.CassandraClient.Commands.System.Write
 {
     internal class DropColumnFamilyCommand : KeyspaceColumnFamilyDependantCommandBase, IFierceCommand
@@ -10,7 +12,7 @@ namespace SKBKontur.Cassandra.CassandraClient.Commands.System.Write
         {
         }
 
-        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient)
+        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient, ILog logger)
         {
             Output = cassandraClient.system_drop_column_family(columnFamily);
         }

--- a/Cassandra.ThriftClient/Commands/System/Write/DropKeyspaceCommand.cs
+++ b/Cassandra.ThriftClient/Commands/System/Write/DropKeyspaceCommand.cs
@@ -1,6 +1,8 @@
 ﻿using SKBKontur.Cassandra.CassandraClient.Abstractions;
 using SKBKontur.Cassandra.CassandraClient.Commands.Base;
 
+using Vostok.Logging.Abstractions;
+
 namespace SKBKontur.Cassandra.CassandraClient.Commands.System.Write
 {
     internal class DropKeyspaceCommand : CommandBase, IFierceCommand
@@ -10,7 +12,7 @@ namespace SKBKontur.Cassandra.CassandraClient.Commands.System.Write
             this.keyspace = keyspace;
         }
 
-        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient)
+        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient, ILog logger)
         {
             Output = cassandraClient.system_drop_keyspace(keyspace);
         }

--- a/Cassandra.ThriftClient/Commands/System/Write/SchemaAgreementCommand.cs
+++ b/Cassandra.ThriftClient/Commands/System/Write/SchemaAgreementCommand.cs
@@ -3,11 +3,13 @@
 using SKBKontur.Cassandra.CassandraClient.Abstractions;
 using SKBKontur.Cassandra.CassandraClient.Commands.Base;
 
+using Vostok.Logging.Abstractions;
+
 namespace SKBKontur.Cassandra.CassandraClient.Commands.System.Write
 {
     internal class SchemaAgreementCommand : CommandBase, IFierceCommand
     {
-        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient)
+        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient, ILog logger)
         {
             Output = cassandraClient.describe_schema_versions();
         }

--- a/Cassandra.ThriftClient/Commands/System/Write/TruncateColumnFamilyCommand.cs
+++ b/Cassandra.ThriftClient/Commands/System/Write/TruncateColumnFamilyCommand.cs
@@ -1,6 +1,8 @@
 ﻿using SKBKontur.Cassandra.CassandraClient.Abstractions;
 using SKBKontur.Cassandra.CassandraClient.Commands.Base;
 
+using Vostok.Logging.Abstractions;
+
 namespace SKBKontur.Cassandra.CassandraClient.Commands.System.Write
 {
     internal class TruncateColumnFamilyCommand : KeyspaceColumnFamilyDependantCommandBase, IFierceCommand
@@ -10,7 +12,7 @@ namespace SKBKontur.Cassandra.CassandraClient.Commands.System.Write
         {
         }
 
-        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient)
+        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient, ILog logger)
         {
             cassandraClient.truncate(columnFamily);
         }

--- a/Cassandra.ThriftClient/Commands/System/Write/UpdateColumnFamilyCommand.cs
+++ b/Cassandra.ThriftClient/Commands/System/Write/UpdateColumnFamilyCommand.cs
@@ -1,6 +1,8 @@
 ﻿using SKBKontur.Cassandra.CassandraClient.Abstractions;
 using SKBKontur.Cassandra.CassandraClient.Commands.Base;
 
+using Vostok.Logging.Abstractions;
+
 namespace SKBKontur.Cassandra.CassandraClient.Commands.System.Write
 {
     internal class UpdateColumnFamilyCommand : KeyspaceDependantCommandBase, IFierceCommand
@@ -11,7 +13,7 @@ namespace SKBKontur.Cassandra.CassandraClient.Commands.System.Write
             this.columnFamilyDefinition = columnFamilyDefinition;
         }
 
-        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient)
+        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient, ILog logger)
         {
             Output = cassandraClient.system_update_column_family(columnFamilyDefinition.ToCassandraCfDef(keyspace));
         }

--- a/Cassandra.ThriftClient/Commands/System/Write/UpdateKeyspaceCommand.cs
+++ b/Cassandra.ThriftClient/Commands/System/Write/UpdateKeyspaceCommand.cs
@@ -1,6 +1,8 @@
 ﻿using SKBKontur.Cassandra.CassandraClient.Abstractions;
 using SKBKontur.Cassandra.CassandraClient.Commands.Base;
 
+using Vostok.Logging.Abstractions;
+
 namespace SKBKontur.Cassandra.CassandraClient.Commands.System.Write
 {
     internal class UpdateKeyspaceCommand : CommandBase, IFierceCommand
@@ -10,7 +12,7 @@ namespace SKBKontur.Cassandra.CassandraClient.Commands.System.Write
             this.keyspaceDefinition = keyspaceDefinition;
         }
 
-        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient)
+        public override void Execute(Apache.Cassandra.Cassandra.Client cassandraClient, ILog logger)
         {
             Output = cassandraClient.system_update_keyspace(keyspaceDefinition.ToCassandraKsDef());
         }

--- a/Cassandra.ThriftClient/Core/ThriftConnection.cs
+++ b/Cassandra.ThriftClient/Core/ThriftConnection.cs
@@ -52,7 +52,7 @@ namespace SKBKontur.Cassandra.CassandraClient.Core
                     logger.Error(e, "Взяли дохлую коннекцию. Время жизни коннекции до этого: {0}", DateTime.UtcNow - CreationDateTime);
                     throw e;
                 }
-                command.Execute(cassandraClient);
+                command.Execute(cassandraClient, logger);
             }
         }
 

--- a/Cassandra.ThriftClient/Exceptions/CassandraClientInvalidResponseException.cs
+++ b/Cassandra.ThriftClient/Exceptions/CassandraClientInvalidResponseException.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+using JetBrains.Annotations;
+
+using SKBKontur.Cassandra.CassandraClient.Abstractions;
+
+namespace SKBKontur.Cassandra.CassandraClient.Exceptions
+{
+    public class CassandraClientInvalidResponseException : CassandraClientException
+    {
+        public CassandraClientInvalidResponseException(string message)
+            : base($"Invalid Cassandra response: {message}")
+        {
+        }
+    }
+}

--- a/Cassandra.ThriftClient/Exceptions/CassandraExceptionTransformer.cs
+++ b/Cassandra.ThriftClient/Exceptions/CassandraExceptionTransformer.cs
@@ -33,6 +33,8 @@ namespace SKBKontur.Cassandra.CassandraClient.Exceptions
                 return new CassandraClientIOException(message, e);
             if (e is SchemaDisagreementException)
                 return new CassandraClientSchemaDisagreementException(message, e);
+            if(e is CassandraClientInvalidResponseException)
+                return (CassandraClientInvalidResponseException)e;
             return new CassandraUnknownException(message, e);
             // ReSharper restore CanBeReplacedWithTryCastAndCheckForNull
         }

--- a/Cassandra.ThriftClient/Helpers/MultigetQueryHelper.cs
+++ b/Cassandra.ThriftClient/Helpers/MultigetQueryHelper.cs
@@ -12,6 +12,12 @@ using Vostok.Logging.Abstractions;
 
 namespace SKBKontur.Cassandra.CassandraClient.Helpers
 {
+    /// <summary>
+    /// There is a bug in the Cassandra that was introduced in the multiget_slice/multiget_count Thrift queries since version 3.0.
+    /// This bug affects read in such a way that Cassandra sometimes doesn't return all the requested data but only return the prefix of the requested keys.
+    /// <see cref="MultigetQueryHelper "/> retries queries in case of bug affection and avoids any data skips at the cost of longer requests. 
+    /// See more details in the issue: https://issues.apache.org/jira/browse/CASSANDRA-14812
+    /// </summary>
     internal class MultigetQueryHelper
     {
         internal MultigetQueryHelper(string commandName, string keyspace, string columnFamily, ConsistencyLevel? consistencyLevel)

--- a/Cassandra.ThriftClient/Helpers/MultigetQueryHelper.cs
+++ b/Cassandra.ThriftClient/Helpers/MultigetQueryHelper.cs
@@ -32,7 +32,7 @@ namespace SKBKontur.Cassandra.CassandraClient.Helpers
         internal Dictionary<byte[], TValue> EnumerateAllKeysWithPartialFetcher<TValue>(
             [NotNull] List<byte[]> keys,
             [NotNull] Func<List<byte[]>, Dictionary<byte[], TValue>> partialFetcher,
-            [CanBeNull] ILog logger = null)
+            [NotNull] ILog logger)
         {
             var keysToFetch = new HashSet<byte[]>(keys, ByteArrayEqualityComparer.Instance);
             var output = new Dictionary<byte[], TValue>();
@@ -51,7 +51,7 @@ namespace SKBKontur.Cassandra.CassandraClient.Helpers
 
             if (attempts > 1)
             {
-                logger?.Warn($"Query with parameters {QueryParameters} enumerates {keys.Count} partitions in {attempts} attempts");
+                logger.Warn($"Query with parameters {QueryParameters} enumerates {keys.Count} partitions in {attempts} attempts");
             }
 
             return output;

--- a/Cassandra.ThriftClient/Helpers/MultigetQueryHelper.cs
+++ b/Cassandra.ThriftClient/Helpers/MultigetQueryHelper.cs
@@ -13,10 +13,10 @@ using Vostok.Logging.Abstractions;
 namespace SKBKontur.Cassandra.CassandraClient.Helpers
 {
     /// <summary>
-    /// There is a bug in the Cassandra that was introduced in the multiget_slice/multiget_count Thrift queries since version 3.0.
-    /// This bug affects read in such a way that Cassandra sometimes doesn't return all the requested data but only return the prefix of the requested keys.
-    /// <see cref="MultigetQueryHelper "/> retries queries in case of bug affection and avoids any data skips at the cost of longer requests. 
-    /// See more details in the issue: https://issues.apache.org/jira/browse/CASSANDRA-14812
+    ///     There is a bug in the Cassandra that was introduced in the multiget_slice/multiget_count Thrift queries since version 3.0.
+    ///     This bug affects read in such a way that Cassandra sometimes doesn't return all the requested data but only return the prefix of the requested keys.
+    ///     <see cref="MultigetQueryHelper " /> retries queries in case of bug affection and avoids any data skips at the cost of longer requests.
+    ///     See more details in the issue: https://issues.apache.org/jira/browse/CASSANDRA-14812
     /// </summary>
     internal class MultigetQueryHelper
     {

--- a/Cassandra.ThriftClient/Helpers/MultigetQueryHelper.cs
+++ b/Cassandra.ThriftClient/Helpers/MultigetQueryHelper.cs
@@ -12,9 +12,9 @@ using Vostok.Logging.Abstractions;
 
 namespace SKBKontur.Cassandra.CassandraClient.Helpers
 {
-    internal class MultigetQueryHelpers
+    internal class MultigetQueryHelper
     {
-        internal MultigetQueryHelpers(string commandName, string keyspace, string columnFamily, ConsistencyLevel? consistencyLevel)
+        internal MultigetQueryHelper(string commandName, string keyspace, string columnFamily, ConsistencyLevel? consistencyLevel)
         {
             this.commandName = commandName;
             this.keyspace = keyspace;

--- a/Cassandra.ThriftClient/Helpers/MultigetQueryHelpers.cs
+++ b/Cassandra.ThriftClient/Helpers/MultigetQueryHelpers.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+using Apache.Cassandra;
+
 using JetBrains.Annotations;
 
 using SKBKontur.Cassandra.CassandraClient.Exceptions;
@@ -10,10 +12,21 @@ using Vostok.Logging.Abstractions;
 
 namespace SKBKontur.Cassandra.CassandraClient.Helpers
 {
-    internal static class MultigetQueryHelpers
+    internal class MultigetQueryHelpers
     {
+        private readonly string keyspace;
+        private readonly string columnFamily;
+        private readonly ConsistencyLevel? consistencyLevel;
+
+        internal MultigetQueryHelpers(string keyspace, string columnFamily, ConsistencyLevel? consistencyLevel)
+        {
+            this.keyspace = keyspace;
+            this.columnFamily = columnFamily;
+            this.consistencyLevel = consistencyLevel;
+        }
+
         [NotNull]
-        internal static Dictionary<byte[], TValue> EnumerateAllKeysWithPartialFetcher<TValue>(
+        internal Dictionary<byte[], TValue> EnumerateAllKeysWithPartialFetcher<TValue>(
             [NotNull] List<byte[]> keys,
             [NotNull] Func<List<byte[]>, Dictionary<byte[], TValue>> partialFetcher,
             [CanBeNull] ILog logger = null)
@@ -35,22 +48,24 @@ namespace SKBKontur.Cassandra.CassandraClient.Helpers
 
             if(attempts > 1)
             {
-                logger?.Warn($"Enumerate {keys.Count} partitions in {attempts} attempts");
+                logger?.Warn($"Query with parameters {QueryParameters} enumerates {keys.Count} partitions in {attempts} attempts");
             }
 
             return output;
         }
 
         [NotNull]
-        private static Dictionary<byte[], TValue> FetchPartialResult<TValue>(
+        private Dictionary<byte[], TValue> FetchPartialResult<TValue>(
             [NotNull] List<byte[]> keys,
             [NotNull] Func<List<byte[]>, Dictionary<byte[], TValue>> partialFetcher)
         {
             var maybePartialOutput = partialFetcher(keys);
             if(maybePartialOutput.Count == 0)
-                throw new CassandraClientInvalidResponseException($"Queried {keys.Count} partitions, Cassandra returned empty result");
+                throw new CassandraClientInvalidResponseException($"Queried {keys.Count} partitions with parameters {QueryParameters}, Cassandra returned empty result");
 
             return maybePartialOutput;
         }
+
+        private string QueryParameters => $"[keyspace='{keyspace}', columnFamily='{columnFamily}', consistencyLevel={consistencyLevel}]";
     }
 }

--- a/Cassandra.ThriftClient/Helpers/MultigetQueryHelpers.cs
+++ b/Cassandra.ThriftClient/Helpers/MultigetQueryHelpers.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using JetBrains.Annotations;
+
+using SKBKontur.Cassandra.CassandraClient.Exceptions;
+
+using Vostok.Logging.Abstractions;
+using Vostok.Logging.Abstractions.Extensions;
+
+namespace SKBKontur.Cassandra.CassandraClient.Helpers
+{
+    internal static class MultigetQueryHelpers
+    {
+        [NotNull]
+        internal static Dictionary<byte[], TValue> EnumerateAllKeysWithPartialFetcher<TValue>(
+            [NotNull] List<byte[]> keys,
+            [NotNull] Func<List<byte[]>, Dictionary<byte[], TValue>> partialFetcher,
+            [CanBeNull] ILog logger = null)
+        {
+            var keysToFetch = new HashSet<byte[]>(keys, ByteArrayEqualityComparer.Instance);
+            var output = new Dictionary<byte[], TValue>();
+            var attempts = 0;
+            while(keysToFetch.Any())
+            {
+                var maybePartialOutput = FetchPartialResult(keysToFetch.ToList(), partialFetcher);
+                foreach(var item in maybePartialOutput)
+                {
+                    output.Add(item.Key, item.Value);
+                    keysToFetch.Remove(item.Key);
+                }
+
+                attempts++;
+            }
+
+            if(attempts > 1)
+            {
+                logger?.Warn($"Enumerate {keys.Count} partitions in {attempts} attempts");
+            }
+
+            return output;
+        }
+
+        [NotNull]
+        private static Dictionary<byte[], TValue> FetchPartialResult<TValue>(
+            [NotNull] List<byte[]> keys,
+            [NotNull] Func<List<byte[]>, Dictionary<byte[], TValue>> partialFetcher)
+        {
+            var maybePartialOutput = partialFetcher(keys);
+            if(maybePartialOutput.Count == 0)
+                throw new CassandraClientInvalidResponseException($"Queried {keys.Count} partitions, Cassandra returned empty result");
+
+            return maybePartialOutput;
+        }
+    }
+}

--- a/Cassandra.ThriftClient/Helpers/MultigetQueryHelpers.cs
+++ b/Cassandra.ThriftClient/Helpers/MultigetQueryHelpers.cs
@@ -7,7 +7,6 @@ using JetBrains.Annotations;
 using SKBKontur.Cassandra.CassandraClient.Exceptions;
 
 using Vostok.Logging.Abstractions;
-using Vostok.Logging.Abstractions.Extensions;
 
 namespace SKBKontur.Cassandra.CassandraClient.Helpers
 {


### PR DESCRIPTION
There is a nasty bug in the Cassandra 3.x when in some cases only part of the requested rows returned for the MultiGetSlice/MultiGetCount commands (read more details in the issue [CASSANDRA-14812](https://issues.apache.org/jira/browse/CASSANDRA-14812)). 

This PR adapts client to this behavior in such a way that in case of partial return client retry the request with remain keys that was not returned in the last responses. The retries continue until all the partitions are returned. The client can't get into the infinite loop because it throws an exception in case of empty response from Cassandra.

Also, PR propagates logger to the `ICommand` execute method and introduce new client-side exception `CasssandraClientInvalidResponse`.